### PR TITLE
Enable custom regex engine use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ List<RecogMatchResult> matchResults = recog.fingerprint("Apache HTTPD 6.5");
 // draw the rest of the owl...
 ```
 
+#### Configuring Pattern Matching
+
+By default, recog-java uses Java's standard regular expression package, `java.util.regex`. To use a different implementation, users can implement their own `RecogPatternMatcher` instance:
+
+```java
+import com.rapid7.recog.pattern.RecogPatternMatcher;
+
+public class CustomPatternMatcher implements RecogPatternMatcher {
+  // custom implementation...
+}
+
+RecogPatternMatcher patternMatcher = new CustomPatternMatcher("^Apache HTTPD (?<version>.*)$");
+RecogMatcher matcher = new RecogMatcher(patternMatcher);
+Map<String, String> results = matcher.match("Apache HTTPD 6.5");
+```
+
 ## Differences from Ruby implementation
 
 This library is not yet at a 1:1 parity with the original [rapid7/recog](https://github.com/rapid7/recog) Ruby implementation.

--- a/src/main/java/com/rapid7/recog/pattern/JavaRegexRecogPatternMatcher.java
+++ b/src/main/java/com/rapid7/recog/pattern/JavaRegexRecogPatternMatcher.java
@@ -1,0 +1,89 @@
+package com.rapid7.recog.pattern;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An implementation of {@link RecogPatternMatcher} that uses java.util.regex.*
+ * packages to match fingerprint values against fingerprint patterns.
+ * Matching of the patterns specified is performed using a sub-sequence or "partial"
+ * match. See {@link Matcher#find()} vs {@link Matcher#matches()}.
+ */
+public class JavaRegexRecogPatternMatcher implements RecogPatternMatcher {
+
+  private static class JavaRegexRecogPatternMatchResult implements RecogPatternMatchResult {
+    private final Matcher matcher;
+
+    JavaRegexRecogPatternMatchResult(Matcher matcher) {
+      this.matcher = matcher;
+    }
+
+    @Override
+    public int groupCount() {
+      return matcher.groupCount();
+    }
+
+    @Override
+    public String group(int group) {
+      return matcher.group(group);
+    }
+
+    @Override
+    public String group(String group) {
+      return matcher.group(group);
+    }
+  }
+
+  /**
+   * The regular expression pattern to match.
+   */
+  private final Pattern pattern;
+
+  public JavaRegexRecogPatternMatcher(Pattern pattern) {
+    this.pattern = requireNonNull(pattern);
+  }
+
+  @Override
+  public String getPattern() {
+    return pattern.pattern();
+  }
+
+  @Override
+  public int getFlags() {
+    return pattern.flags();
+  }
+
+  @Override
+  public boolean matches(String input) {
+    return input != null && pattern.matcher(input).find();
+  }
+
+  @Override
+  public RecogPatternMatchResult match(String input) {
+    if (input == null) {
+      return null;
+    }
+    Matcher matcher = pattern.matcher(input);
+    return matcher.find() ? new JavaRegexRecogPatternMatchResult(matcher) : null;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof JavaRegexRecogPatternMatcher)) {
+      return false;
+    } else {
+      JavaRegexRecogPatternMatcher that = (JavaRegexRecogPatternMatcher) other;
+      return Objects.equals(getPattern(), that.getPattern())
+          && Objects.equals(getFlags(), that.getFlags());
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pattern);
+  }
+}

--- a/src/main/java/com/rapid7/recog/pattern/RecogPatternMatchResult.java
+++ b/src/main/java/com/rapid7/recog/pattern/RecogPatternMatchResult.java
@@ -1,0 +1,34 @@
+package com.rapid7.recog.pattern;
+
+/**
+ * The result of a match operation.
+ */
+public interface RecogPatternMatchResult {
+
+  /**
+   * Returns the number of capturing groups in this result.
+   */
+  int groupCount();
+
+  /**
+   * Returns the input captured by the indexed group.
+   *
+   * @param index The index of the capturing group. Group indexes start at one.
+   * @return The input captured by the group at the specified index, or {@code null}
+   *     if there is no matching input for this group.
+   * @throws IndexOutOfBoundsException if the index is less than 1 or greater than
+   *     that returned of {@code groupCount()}.
+   */
+  String group(int index);
+
+  /**
+   * Returns the input captured by the named group.
+   *
+   * @param name The name of the capturing group.
+   * @return Input captured by the named group or {@code null} if there is no
+   *     matching input for this group.
+   * @throws IllegalArgumentException if there is no group with this name.
+   */
+  String group(String name);
+
+}

--- a/src/main/java/com/rapid7/recog/pattern/RecogPatternMatcher.java
+++ b/src/main/java/com/rapid7/recog/pattern/RecogPatternMatcher.java
@@ -1,0 +1,32 @@
+package com.rapid7.recog.pattern;
+
+/**
+ * Performs matching of input values against a regular expression that supports grouped parameter
+ * extraction.
+ */
+public interface RecogPatternMatcher {
+
+  /** The regex pattern this matcher matches. */
+  String getPattern();
+
+  int getFlags();
+
+  /**
+   * Returns whether this matcher matches the specified input fingerprint value.
+   *
+   * @param input The fingerprint to test this matcher against. May be {@code null}.
+   * @return {@code true} if the input is non-{@code null} and matches the fingerprint matcher
+   *     pattern.
+   */
+  boolean matches(String input);
+
+  /**
+   * Matches the regular expression against the specified input.
+   *
+   * @param input The fingerprint to match. May be {@code null}.
+   * @return {@code null} if the input does not match the pattern, otherwise a non-{@code null}
+   *     {@link RecogPatternMatchResult}
+   */
+  RecogPatternMatchResult match(String input);
+
+}

--- a/src/test/java/com/rapid7/recog/CustomPatternMatcherTest.java
+++ b/src/test/java/com/rapid7/recog/CustomPatternMatcherTest.java
@@ -1,0 +1,72 @@
+package com.rapid7.recog;
+
+import com.rapid7.recog.pattern.RecogPatternMatchResult;
+import com.rapid7.recog.pattern.RecogPatternMatcher;
+import java.util.AbstractMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+public class CustomPatternMatcherTest {
+
+  private static class EchoPatternMatcher implements RecogPatternMatcher {
+
+    @Override
+    public String getPattern() {
+      return null;
+    }
+
+    @Override
+    public int getFlags() {
+      return 0;
+    }
+
+    @Override
+    public boolean matches(String input) {
+      return true;
+    }
+
+    @Override
+    public RecogPatternMatchResult match(String input) {
+      return new RecogPatternMatchResult() {
+        @Override
+        public int groupCount() {
+          return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public String group(int index) {
+          return "group: " + index;
+        }
+
+        @Override
+        public String group(String name) {
+          return "group: " + name;
+        }
+      };
+    }
+  }
+
+  @Test
+  public void customMatcherTest() {
+    // given
+    RecogPatternMatcher patternMatcher = new EchoPatternMatcher();
+    RecogMatcher matcher = new RecogMatcher(patternMatcher)
+        .addParam(1, "1")
+        .addParam(2, "2")
+        .addParam("name");
+
+    // when
+    Map<String, String> matches = matcher.match("arbitrary text input");
+
+    // then
+    assertThat(matches.entrySet(), hasSize(3));
+    assertThat(matches.entrySet(), containsInAnyOrder(
+        new AbstractMap.SimpleEntry<>("1", "group: 1"),
+        new AbstractMap.SimpleEntry<>("2", "group: 2"),
+        new AbstractMap.SimpleEntry<>("name", "group: name")
+    ));
+  }
+}


### PR DESCRIPTION
Enable custom regex engine use.

Allow library users to customize the regular expression engine used
during fingerprint matching. Custom regex engines can be configured
by implementing the `RecogPatternMatcher` interface.

This feature is desirable as Java's regex engine is susceptible to
catastrophic backtracking.

## Description
- Add the `RecogPatternMatcher` interface.
- Update `RecogMatcher` to use an underlying `RecogPatternMatcher` instance, rather than `java.regex.*` classes directly
- Implement a `JavaRegexRecogMatcher` to use as a default an provide backwards compatability.

## How Has This Been Tested?
- `JavaRegexRecogMatcher` has been exercised via existing unit tests. Since it is the default, it is used in all existing tests.
- `CustomPatternMatcherTest` has been added to validate custom `RecogPatternMatchers` may be used.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
