### PR TITLE
Update RecogParser#PatternMatcherFactory to be public.

### DIFF
--- a/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -33,7 +33,7 @@ public class RecogParser {
    * Factory used to create the underlying {@link RecogPatternMatcher} used
    * when matching inputs against regular expressions.
    */
-  interface PatternMatcherFactory {
+  public interface PatternMatcherFactory {
     RecogPatternMatcher create(String pattern, int flags);
   }
 


### PR DESCRIPTION
Previously, this interface was package-private and didn't support library users supplying their own factories.